### PR TITLE
Style: Hiding overflow-y for Grid

### DIFF
--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -15,7 +15,7 @@ export const SGrid = styled.div<IGridStyleProps>`
   height: 100%;
   padding: 24px;
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: hidden;
   background: rgb(${colors.white});
 
   display: grid;


### PR DESCRIPTION
For some reason, overflow-y for grid in /apps was defined as "scroll".
Removing that for aesthetics, since all the logos are visible at once
anyway.