### PR TITLE
Fix deformed homepage image

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -30,7 +30,7 @@ const Banner = () => (
       <h2 className="flex justify-center text-3xl font-thin text-center">
         Open protocol for connecting Wallets to Dapps
       </h2>
-      <div className="mt-14 lg:flex lg:justify-center">
+      <div className="mt-14 lg:flex lg:justify-center mt-14 lg:flex-col lg:items-center">
         <img
           className="lg:max-w-4xl"
           src="banner-main.png"


### PR DESCRIPTION
On Safari, the homepage image is deformed/stretched. This should fix it, assuming Tailwind has `lg:` variants for the added flex classes.

Before:
<img width="1175" alt="Snímek obrazovky 2021-08-24 v 19 11 15" src="https://user-images.githubusercontent.com/5470780/130660146-32c93c6c-1e1c-4e80-a901-ee674da8c670.png">

After:
<img width="1171" alt="Snímek obrazovky 2021-08-24 v 19 11 03" src="https://user-images.githubusercontent.com/5470780/130660113-bf7fb963-ac5a-4da0-bb2c-40b88ef91b9c.png">